### PR TITLE
Fix big coverart issue

### DIFF
--- a/style/Style.css
+++ b/style/Style.css
@@ -495,6 +495,7 @@ table.songlist tr.song td.album img
     float: left;
     margin: 0 5px;
     padding: 2px;
+    height: 36px;
 }
 table.songlist tr.song td.artist
 {


### PR DESCRIPTION
CoverArt from Subsonic could break minisub song list.

The fix solves the following issue:

what:
- in case of big coverart

expected behaviour:
- MiniSub resize the coverart to the height of the tr.song

instead:
- Images were not resized and huge images broke the page
