### PR TITLE
use setMedia for m4a filetype

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -250,6 +250,10 @@
                     $(this).jPlayer("setMedia", {
                         mp3: url
                     });
+                } else if (suffix == 'm4a') {
+                    $(this).jPlayer("setMedia", {
+                        m4a: url
+                    });
                 }
                 if (!loadonly) { // Start playing
                     $(this).jPlayer("play");


### PR DESCRIPTION
Without this set when trying to play m4a files Jamstash hits "Uncaught RangeError: Maximum call stack size exceeded" and fails to load the file. Tested working after patch.
