### PR TITLE
Faster Grunt serve, test coverage, notifications

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components
 node_modules
 /.tmp
 /.ssh
+/coverage

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,8 @@
 
 module.exports = function (grunt) {
 
-  grunt.loadNpmTasks('grunt-karma');
+  // Lazy-load grunt tasks automatically
+  require('jit-grunt')(grunt);
 
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
@@ -368,9 +369,6 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('serve', 'Compile then start a connect web server', function(target) {
-    // Load grunt tasks automatically
-    require('load-grunt-tasks')(grunt);
-
     if (target === 'dist') {
       return grunt.task.run(['build', 'connect:dist:keepalive']);
     }
@@ -384,9 +382,6 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('test', 'Run unit tests and jshint', function() {
-    // Load grunt tasks automatically
-    require('load-grunt-tasks')(grunt);
-
     return grunt.task.run([
       'karma:unit',
       'jshint'
@@ -394,9 +389,6 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('coverage', 'Run unit tests and display test coverage results on browser', function() {
-    // Load grunt tasks automatically
-    require('load-grunt-tasks')(grunt);
-
     return grunt.task.run([
       'karma:unit',
       'connect:coverage'
@@ -404,9 +396,6 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('build', 'Concatenate all JS files, minify all JS, CSS, HTML and image files and version all static assets', function() {
-    // Load grunt tasks automatically
-    require('load-grunt-tasks')(grunt);
-
     return grunt.task.run([
       'clean:dist',
       'wiredep:app',
@@ -424,9 +413,6 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('deploy', 'Build and deploy to test server', function() {
-    // Load grunt tasks automatically
-    require('load-grunt-tasks')(grunt);
-
     return grunt.task.run([
       'build',
       'sshexec:cleanTest',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,11 @@
 module.exports = function (grunt) {
 
   // Lazy-load grunt tasks automatically
-  require('jit-grunt')(grunt);
+  require('jit-grunt')(grunt, {
+    useminPrepare: 'grunt-usemin',
+    sshexec: 'grunt-ssh',
+    sftp: 'grunt-ssh'
+  });
 
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,12 +116,13 @@ module.exports = function (grunt) {
       unit: {
         singleRun: true,
         browsers: ['Chrome'],
-        reporters: ['progress', 'coverage']
+        reporters: ['growl', 'coverage']
       },
       continuous: {
         singleRun: false,
         background: true,
-        browsers: ['PhantomJS']
+        browsers: ['PhantomJS'],
+        reporters: ['progress', 'growl']
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -115,7 +115,8 @@ module.exports = function (grunt) {
       },
       unit: {
         singleRun: true,
-        browsers: ['Chrome']
+        browsers: ['Chrome'],
+        reporters: ['progress', 'coverage']
       },
       continuous: {
         singleRun: false,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,8 +9,7 @@
 
 module.exports = function (grunt) {
 
-  // Load grunt tasks automatically
-  require('load-grunt-tasks')(grunt);
+  grunt.loadNpmTasks('grunt-karma');
 
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
@@ -368,7 +367,10 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('serve', 'Compile then start a connect web server', function (target) {
+  grunt.registerTask('serve', 'Compile then start a connect web server', function(target) {
+    // Load grunt tasks automatically
+    require('load-grunt-tasks')(grunt);
+
     if (target === 'dist') {
       return grunt.task.run(['build', 'connect:dist:keepalive']);
     }
@@ -381,32 +383,50 @@ module.exports = function (grunt) {
       ]);
   });
 
-  grunt.registerTask('test', [
-    'karma:unit',
-    'jshint'
-  ]);
+  grunt.registerTask('test', 'Run unit tests and jshint', function() {
+    // Load grunt tasks automatically
+    require('load-grunt-tasks')(grunt);
 
-  grunt.registerTask('coverage', [
-    'karma:unit',
-    'connect:coverage'
-  ]);
+    return grunt.task.run([
+      'karma:unit',
+      'jshint'
+    ]);
+  });
 
-  grunt.registerTask('build', [
-    'clean:dist',
-    'wiredep:app',
-    'useminPrepare',
-    'concat:generated',
-    'copy:dist',
-    'imagemin',
-    //'ngAnnotate',
-    'cssmin',
-    'uglify:generated',
-    'filerev',
-    'usemin',
-    'htmlmin'
-  ]);
+  grunt.registerTask('coverage', 'Run unit tests and display test coverage results on browser', function() {
+    // Load grunt tasks automatically
+    require('load-grunt-tasks')(grunt);
+
+    return grunt.task.run([
+      'karma:unit',
+      'connect:coverage'
+    ]);
+  });
+
+  grunt.registerTask('build', 'Concatenate all JS files, minify all JS, CSS, HTML and image files and version all static assets', function() {
+    // Load grunt tasks automatically
+    require('load-grunt-tasks')(grunt);
+
+    return grunt.task.run([
+      'clean:dist',
+      'wiredep:app',
+      'useminPrepare',
+      'concat:generated',
+      'copy:dist',
+      'imagemin',
+      //'ngAnnotate',
+      'cssmin',
+      'uglify:generated',
+      'filerev',
+      'usemin',
+      'htmlmin'
+    ]);
+  });
 
   grunt.registerTask('deploy', 'Build and deploy to test server', function() {
+    // Load grunt tasks automatically
+    require('load-grunt-tasks')(grunt);
+
     return grunt.task.run([
       'build',
       'sshexec:cleanTest',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,18 +86,26 @@ module.exports = function (grunt) {
         }
       },
       test: {
-      options: {
-        port: 9001,
-        middleware: function (connect) {
-          return [
-            connect().use(
-              '/bower_components',
-              connect.static('./bower_components')
-            ),
-            connect.static(appConfig.app)
-          ];
+        options: {
+          port: 9001,
+          middleware: function (connect) {
+            return [
+              connect().use(
+                '/bower_components',
+                connect.static('./bower_components')
+              ),
+              connect.static(appConfig.app)
+            ];
+          }
         }
-      }
+      },
+      coverage: {
+        options: {
+          open: true,
+          port: 9003,
+          keepalive: true,
+          base: './coverage/'
+        }
       },
       dist: {
         options: {
@@ -121,7 +129,7 @@ module.exports = function (grunt) {
       continuous: {
         singleRun: false,
         background: true,
-        browsers: ['PhantomJS'],
+        browsers: ['Chrome'],
         reporters: ['progress', 'growl']
       }
     },
@@ -348,8 +356,16 @@ module.exports = function (grunt) {
           createDirectories: true
         }
       }
-    }
+    },
 
+    // Display notfifications when builds complete using Growl
+    notify: {
+      deploy: {
+        options: {
+          message: 'Jamstash deployed to test server'
+        }
+      }
+    }
   });
 
   grunt.registerTask('serve', 'Compile then start a connect web server', function (target) {
@@ -368,6 +384,11 @@ module.exports = function (grunt) {
   grunt.registerTask('test', [
     'karma:unit',
     'jshint'
+  ]);
+
+  grunt.registerTask('coverage', [
+    'karma:unit',
+    'connect:coverage'
   ]);
 
   grunt.registerTask('build', [
@@ -389,7 +410,8 @@ module.exports = function (grunt) {
     return grunt.task.run([
       'build',
       'sshexec:cleanTest',
-      'sftp:test'
+      'sftp:test',
+      'notify:deploy'
     ]);
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,13 +128,13 @@ module.exports = function (grunt) {
       unit: {
         singleRun: true,
         browsers: ['Chrome'],
-        reporters: ['growl', 'coverage']
+        reporters: ['notify', 'coverage']
       },
       continuous: {
         singleRun: false,
         background: true,
         browsers: ['Chrome'],
-        reporters: ['progress', 'growl']
+        reporters: ['progress', 'notify']
       }
     },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,7 +67,7 @@ module.exports = function(config) {
       'karma-phantomjs-launcher',
       'karma-jasmine',
       'karma-coverage',
-      'karma-growl-reporter'
+      'karma-notify-reporter'
     ],
 
     // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,7 +58,7 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'Chrome'
+      'PhantomJS'
     ],
 
     // Which plugins to enable
@@ -66,7 +66,8 @@ module.exports = function(config) {
       'karma-chrome-launcher',
       'karma-phantomjs-launcher',
       'karma-jasmine',
-      'karma-coverage'
+      'karma-coverage',
+      'karma-growl-reporter'
     ],
 
     // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,6 +42,10 @@ module.exports = function(config) {
     // list of files / patterns to exclude
     exclude: ['app/vendor/**/*.js'],
 
+    preprocessors: {
+      'app/**/!(*_test).js': ['coverage']
+    },
+
     // web server port
     port: 8080,
 
@@ -61,7 +65,8 @@ module.exports = function(config) {
     plugins: [
       'karma-chrome-launcher',
       'karma-phantomjs-launcher',
-      'karma-jasmine'
+      'karma-jasmine',
+      'karma-coverage'
     ],
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "karma": "^0.12.25",
     "karma-chrome-launcher": "^0.1.5",
     "karma-coverage": "^0.2.6",
+    "karma-growl-reporter": "^0.1.1",
     "karma-jasmine": "^0.3.0",
     "karma-phantomjs-launcher": "^0.1.4",
     "load-grunt-tasks": "^1.0.0",
-    "sellout": "0.0.1",
     "time-grunt": "^1.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "grunt-ssh": "^0.12.0",
     "grunt-usemin": "^2.6.0",
     "grunt-wiredep": "^1.9.0",
+    "jit-grunt": "^0.9.0",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.25",
     "karma-chrome-launcher": "^0.1.5",
@@ -53,7 +54,6 @@
     "karma-growl-reporter": "^0.1.1",
     "karma-jasmine": "^0.3.0",
     "karma-phantomjs-launcher": "^0.1.4",
-    "load-grunt-tasks": "^1.0.0",
     "time-grunt": "^1.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.25",
     "karma-chrome-launcher": "^0.1.5",
+    "karma-coverage": "^0.2.6",
     "karma-jasmine": "^0.3.0",
     "karma-phantomjs-launcher": "^0.1.4",
     "load-grunt-tasks": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "grunt-filerev": "^2.1.1",
     "grunt-karma": "^0.9.0",
     "grunt-ng-annotate": "^0.5.0",
+    "grunt-notify": "^0.4.1",
     "grunt-ssh": "^0.12.0",
     "grunt-usemin": "^2.6.0",
     "grunt-wiredep": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "karma": "^0.12.25",
     "karma-chrome-launcher": "^0.1.5",
     "karma-coverage": "^0.2.6",
-    "karma-growl-reporter": "^0.1.1",
     "karma-jasmine": "^0.3.0",
+    "karma-notify-reporter": "^0.1.1",
     "karma-phantomjs-launcher": "^0.1.4",
     "time-grunt": "^1.0.0"
   },


### PR DESCRIPTION
Hi ! Merry Christmas and Happy new year ! (a bit late, I know)

This PR is purely about Grunt and Karma, so nothing user-facing. I haven't updated the version numbers, feel free to bump them in the 3 files.
By the way, while we're talking about versions, please use a 3-part version number (e.g. 4.3.0 instead of 4.3) in `bower.json` and `package.json`, otherwise `npm` and `bower` complain about it and don't install our dependencies.

- Adds an `.editorconfig` file so we can all have the same coding style (regarding spaces/tabs, line-endings, etc.). Check out [editorconfig.org](http://editorconfig.org), they certainly have a plugin for your favorite editor.
- Uses `jit-grunt` instead of `load-grunt-tasks`. This makes `grunt serve` much faster because it no longer loads imagemin, which takes 3 full seconds, on every watch event.
- Adds `grunt-notify` to send a notification when `grunt deploy` is finished. It uses Windows 8, Mac OS X or Linux's notifications. In case you don't have notifications capabilities, nothing changes.
- Adds `karma-coverage` + a new `grunt coverage` task. It generates test coverage data and spins up a static webserver to open it. This lets us know where code is tested and where it is not, so we know where to add tests in priority.
- Adds `karma-notify`. It sends a notification if tests succeed or fail, just like `grunt-notify`.

And that's it ! Best regards