### PR TITLE
Add option to estimate the content length of streamed media

### DIFF
--- a/app/common/model-service.js
+++ b/app/common/model-service.js
@@ -111,6 +111,9 @@ angular.module('jamstash.model', ['jamstash.utils'])
         if (suffix == 'ogg') { suffix = 'oga'; }
         var salt = Math.floor(Math.random() * 100000);
         url = globals.BaseURL() + '/stream.view?' + globals.BaseParams() + '&id=' + song.id + '&salt=' + salt;
+        if (globals.settings.EstimateLength){
+            url += "&estimateContentLength=true";
+        }
         return new model.Song(song.id, song.parent, track, title, artist, song.artistId, song.album, song.albumId, coverartthumb, coverartfull, song.duration, song.userRating, starred, suffix, specs, url, 0, description);
     };
 
@@ -147,6 +150,9 @@ angular.module('jamstash.model', ['jamstash.utils'])
         if (suffix == 'ogg') { suffix = 'oga'; }
         var salt = Math.floor(Math.random() * 100000);
         url = globals.BaseURL() + '/stream.view?' + globals.BaseParams() + '&id=' + song.streamId + '&salt=' + salt;
+        if (globals.settings.EstimateLength){
+            url += "&estimateContentLength=true";
+        }
         return new model.Song(song.streamId, song.parent, track, title, artist, song.artistId, album, song.albumId, coverartthumb, coverartfull, song.duration, song.userRating, starred, suffix, specs, url, 0, description);
     };
 

--- a/app/settings/settings-service.js
+++ b/app/settings/settings-service.js
@@ -58,7 +58,9 @@ angular.module('jamstash.settings.service', [])
         AutoPlay: false,
         LoopQueue: false,
         Repeat: false,
+        // Advanced
         Debug: false,
+        EstimateLength: true,
         ShowQueue: false
     };
     this.SavedCollections = [];

--- a/app/settings/settings.html
+++ b/app/settings/settings.html
@@ -46,10 +46,10 @@
                         <div class="clear"></div>
                         <select id="DefaultLibraryLayout" name="DefaultLibraryLayout" class="" ng-model="settings.DefaultLibraryLayout.id" ng-options="o.id as o.name for o in Layouts" title="Library Layout"></select>
                         <div class="clear"></div>
-						<label for="DefaultSearchType">Default Search Type</label>
-						<div class="clear"></div>
+                        <label for="DefaultSearchType">Default Search Type</label>
+                        <div class="clear"></div>
                         <select id="DefaultSearchType" name="DefaultSearchType" class="" ng-model="settings.DefaultSearchType" ng-options="o.id as o.name for o in SearchTypes" title="Subsonic Album Layout"></select>
-						<div class="clear"></div>
+                        <div class="clear"></div>
                     </fieldset>
                     <div class="clear"></div>
                     <fieldset id="HTML5">
@@ -80,6 +80,9 @@
                         <legend class="aligncenter">Advanced</legend>
                         <div class="inputwrap"><input type="checkbox" id="Debug" name="Debug" value="1" title="Enable Debug Mode (Events will be logged to the Javascript Console)" ng-model="settings.Debug" /></div>
                         <label for="Debug">Debug Mode</label>
+                        <div class="clear"></div>
+                        <div class="inputwrap"><input type="checkbox" id="EstimateLength" name="EstimateLength" value="1" title="Ask the server to estimate the filesize of transcoded media" ng-model="settings.EstimateLength" /></div>
+                        <label for="EstimateLength">Estimate content length</label>
                         <div class="clear"></div>
                         <div class="inputwrap"><input type="checkbox" id="ForceFlash" name="ForceFlash" value="1" title="Force Flash Plugin for Audio (Option doesn't work with Chrome App)" ng-model="settings.ForceFlash" /></div>
                         <label for="ForceFlash">Force Flash</label>


### PR DESCRIPTION
Enabling this can help with seeking within transcoded media.

Without knowing how big a file is, it's impossible to display an
accurate progress bar. This option asks the server to send a
"Content-Length" header with a guess (based on bitrate and song length)
of how big the streamed file is going to be, enabling a progress bar to
be shown.

This reliably works with CBR transcodes, but can have issues with VBR as
the server doesn't know how big the file will be before it's transcoded.
If the server estimates incorrectly then songs could stop playing before
they actually finish or cause other glitches.

For the most part servers are pretty good with their estimates and being
able to seek in a transcoded stream as it downloads is a substantial UX
improvement so the option is enabled by default.