### PR TITLE
Improve song length handling when transcoding

### DIFF
--- a/app/player/player-directive.js
+++ b/app/player/player-directive.js
@@ -114,11 +114,11 @@ angular.module('jamstash.player.directive', ['jamstash.player.service', 'jamstas
                     }
                     var media = {};
                     if (newSong.suffix === 'oga') {
-                        media= { oga: newSong.url };
+                        media= { oga: newSong.url, duration: newSong.duration };
                     } else if (newSong.suffix === 'm4a') {
-                        media= { m4a: newSong.url };
+                        media= { m4a: newSong.url, duration: newSong.duration };
                     } else if (newSong.suffix === 'mp3') {
-                        media= { mp3: newSong.url };
+                        media= { mp3: newSong.url, duration: newSong.duration };
                     }
                     $player.jPlayer('setMedia', media);
                     if (globals.settings.Jukebox) {


### PR DESCRIPTION
d2e57cc introduced the "Estimate Content Length" option for transcoded streams. As stated in the commit itself, this option has its limitations, especially with VBR transcoding.
This PR reverts that commit, effectively removing the option, and replaces it with jplayer's `duration` option. We provide the known song length to jplayer directly rather than asking the server to estimate.