### PR TITLE
Cosmetic fixes: albumart thumbnails, favicon

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -203,10 +203,15 @@ module.exports = function (grunt) {
         assetsDirs: ['<%= yeoman.dist %>','<%= yeoman.dist %>/images', '<%= yeoman.dist %>/styles'],
         patterns: {
           js: [
-            [/(images\/albumdefault_50\.jpg)/, 'Replace javascript references to the album default image'],
-            [/(images\/albumdefault_60\.jpg)/, 'Replace javascript references to the album default image'],
-            [/(images\/albumdefault_160\.jpg)/, 'Replace javascript references to the album default image'],
+            [/(images\/albumdefault_50\.jpg)/g, 'Replace javascript references to the album default image'],
+            [/(images\/albumdefault_60\.jpg)/g, 'Replace javascript references to the album default image'],
+            [/(images\/albumdefault_160\.jpg)/g, 'Replace javascript references to the album default image'],
             [/(styles\/Dark\.css)/, 'Replace javascript references to the theme CSS']
+          ],
+          html: [
+            [/(images\/albumdefault_50\.jpg)/g, 'Replace javascript references to the album default image'],
+            [/(images\/albumdefault_60\.jpg)/g, 'Replace javascript references to the album default image'],
+            [/(images\/albumdefault_160\.jpg)/g, 'Replace javascript references to the album default image']
           ]
         }
       }

--- a/app/common/directives.js
+++ b/app/common/directives.js
@@ -95,4 +95,13 @@ angular.module('JamStash')
             }
         });
     };
+})
+.directive('checkImage', function() {
+   return {
+      link: function(scope, element, attrs) {
+         element.bind('error', function() {
+            element.attr('src', '/images/albumdefault_160.jpg'); // set default image
+         });
+       }
+   }
 });

--- a/app/common/model-service.js
+++ b/app/common/model-service.js
@@ -66,6 +66,9 @@ angular.module('jamstash.model', ['jamstash.utils'])
         if (typeof album.coverArt != 'undefined') {
             coverartthumb = globals.BaseURL() + '/getCoverArt.view?' + globals.BaseParams() + '&size=160&id=' + album.coverArt;
             coverartfull = globals.BaseURL() + '/getCoverArt.view?' + globals.BaseParams() + '&id=' + album.coverArt;
+        } else {
+            coverartthumb = 'images/albumdefault_60.jpg';
+            coverartfull = 'images/albumdefault_160.jpg';
         }
         if (typeof album.starred !== 'undefined') { starred = true; } else { starred = false; }
         if (typeof album.title !== 'undefined') { title = album.title; } else { title = album.name; }
@@ -137,6 +140,9 @@ angular.module('jamstash.model', ['jamstash.utils'])
         if (typeof song.coverArt != 'undefined') {
             coverartthumb = globals.BaseURL() + '/getCoverArt.view?' + globals.BaseParams() + '&size=60&id=' + song.coverArt;
             coverartfull = globals.BaseURL() + '/getCoverArt.view?' + globals.BaseParams() + '&id=' + song.coverArt;
+        } else {
+            coverartthumb = 'images/albumdefault_60.jpg';
+            coverartfull = 'images/albumdefault_160.jpg';
         }
         if (typeof song.album == 'undefined') { album = '&nbsp;'; } else { album = song.album.toString(); }
         if (typeof song.artist == 'undefined') { artist = '&nbsp;'; } else { artist = song.artist.toString(); }

--- a/app/common/model-service.js
+++ b/app/common/model-service.js
@@ -67,7 +67,7 @@ angular.module('jamstash.model', ['jamstash.utils'])
             coverartthumb = globals.BaseURL() + '/getCoverArt.view?' + globals.BaseParams() + '&size=160&id=' + album.coverArt;
             coverartfull = globals.BaseURL() + '/getCoverArt.view?' + globals.BaseParams() + '&id=' + album.coverArt;
         } else {
-            coverartthumb = 'images/albumdefault_60.jpg';
+            coverartthumb = 'images/albumdefault_160.jpg';
             coverartfull = 'images/albumdefault_160.jpg';
         }
         if (typeof album.starred !== 'undefined') { starred = true; } else { starred = false; }

--- a/app/common/songs.html
+++ b/app/common/songs.html
@@ -11,7 +11,7 @@
     <div class="title floatleft" title="{{o.description}}" ng-bind-html="o.name"></div>
     <span class="artist floatleft" ng-bind-html="o.artist"></span>
     <div ng-show="o.album && itemType !== 'archive'">
-        <img ng-src="{{o.coverartthumb}}">
+        <img check-image ng-src="{{o.coverartthumb}}">
         <a ng-href="#/library/0/{{o.albumId}}" class="albumblock floatleft" stop-event="click" ng-bind-html="o.album" title="{{o.album}}"></a>
     </div>
     <a ng-show="o.album && itemType === 'archive'" ng-href="#/archive/{{o.artist}}/{{o.parentid}}" class="albumblock floatleft" stop-event="click" ng-bind-html="o.album" title="{{o.album}}"></a>

--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,7 @@
     <meta property="og:image" content="http://jamstash.com/images/fbpreview.png"/>
     <meta name=viewport content="width=device-width, initial-scale=1">
     <title ng-bind="Page.title()">Jamstash</title>
-    <link href="images/favicon_32x32.ico" rel="shortcut icon" />
+    <link href="images/favicon_32x32.png" rel="shortcut icon" />
     <link rel="icon" href="images/favicon_48x48.png" sizes="48x48"/>
     <link rel="icon" href="images/favicon_32x32.png" sizes="32x32"/>
     <!-- build:css(.) styles/vendor.min.css -->

--- a/app/subsonic/subsonic.html
+++ b/app/subsonic/subsonic.html
@@ -51,7 +51,7 @@
                                 <a class="hover" href="" title="Star" ng-class="{'favorite': o.starred, 'rate': !o.starred}" ng-click="toggleStar(o)" stop-event="click"></a>
                                 <a class="info hover" href="" title="{{'Created: ' + o.date}}"></a>
                             </div>
-                            <div class="albumart"><img ng-src="{{o.coverartthumb}}" src="images/albumdefault_160.jpg"></div>
+                            <div class="albumart"><img check-image ng-src="{{o.coverartthumb}}" src="images/albumdefault_160.jpg"></div>
                             <div class="albuminfo">
                                 <div class="title" title="{{o.name}}" ng-bind-html="o.name"></div>
                                 <div class="artist" title="{{o.artist}}"><a href="" id="{{o.parentid}}" ng-click="getDirectory('display', o.parentid, o.artist, 'forward')" stop-event="click" ng-bind-html="o.artist"></a></div>
@@ -59,7 +59,7 @@
                             <div class="clear"></div>
                         </li>
                         <li class="album" ng-switch-when="bytag" id="{{o.id}}" ng-class="{'selected': selectedAlbum == o.id, 'albumgrid': settings.DefaultLibraryLayout.id == 'grid'}" ng-click="getAlbumByTag(o.id)">
-                            <div class="albumart"><img ng-src="{{o.coverartthumb}}" src="images/albumdefault_160.jpg"></div>
+                            <div class="albumart"><img check-image ng-src="{{o.coverartthumb}}" src="images/albumdefault_160.jpg"></div>
                             <div class="albuminfo">
                                 <div class="title" title="{{o.name}}" ng-bind-html="o.name"></div>
                                 <div class="artist" title="{{o.artist}}"><a href="" ng-click="getArtistByTag(o.artistId)" stop-event="click" ng-bind-html="o.artist"></a></div>


### PR DESCRIPTION
There are few cases when album covers are missed on the server so broken picture frames are shown in the player. I've added some checks to handle them and replace with default album/artist icon.

In Gruntfile.js uglification patterns also were needed to be global (as grunt replaces only the first occurrence of pattern by default)